### PR TITLE
Update knowledge_base.gemspec

### DIFF
--- a/knowledge_base.gemspec
+++ b/knowledge_base.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-  s.test_files = Dir["spec/**/*"]
+  s.test_files = Dir["spec/**/*", "fixtures/**/*"]
 
   s.add_dependency "rails", "~> 4.0"
   s.add_dependency "friendly_id", "~> 5.0.0"


### PR DESCRIPTION
Fixtures is not being copied to the lib folder, but it's being accessed [here](https://github.com/hyperoslo/knowledge_base/blob/8f67b694b76e76e25089e763bf3fb05c3eb7af97/lib/knowledge_base/seeds.rb#L6).

So after running:

``` bash
rake knowledge_base:seed
```

I get this error:

```
rake aborted!
No such file or directory - /Library/Ruby/Gems/2.0.0/gems/knowledge_base-0.1.0/lib/knowledge_base/../../fixtures/parrot.png
```
# please review
